### PR TITLE
fixed a bug with fixed drawer and screen size 1024px

### DIFF
--- a/src/Material/Layout.elm
+++ b/src/Material/Layout.elm
@@ -295,7 +295,7 @@ update_ f action model =
             -}
             let
                 isSmall =
-                    1024 > width
+                    1024 >= width
 
                 tabScrollState =
                     model.tabScrollState.width


### PR DESCRIPTION
When the drawer is fixed and the resolution is 1024 the the drawer is hidden but the header is still as if the drawer is still present. Check it out: http://material.io/resizer/ and use https://debois.github.io/elm-mdl/#layout (change the drawer to fixed in the middle screen).